### PR TITLE
feat: allow symfony6, add missing doctrine/orm in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=7.2.5",
         "symfony/http-kernel": "^4.4 || ^5.1 || ^6.0",
         "api-platform/core": "^2.5",
-        "doctrine/orm": "^2.0"
+        "doctrine/orm": "^2.8"
     },
     "require-dev": {
     },
@@ -27,6 +27,11 @@
     "autoload-dev": {
         "psr-4": {
             "Metaclass\\LogicalFilterBundle\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": false
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,5 @@
         "psr-4": {
             "Metaclass\\LogicalFilterBundle\\Tests\\": "tests/"
         }
-    },
-    "config": {
-        "allow-plugins": {
-            "composer/package-versions-deprecated": false
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,9 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.2.5",
-        "symfony/http-kernel": "^4.4 || ^5.1",
-        "api-platform/core": "^2.5"
+        "symfony/http-kernel": "^4.4 || ^5.1 || ^6.0",
+        "api-platform/core": "^2.5",
+        "doctrine/orm": "^2.0"
     },
     "require-dev": {
     },


### PR DESCRIPTION
Hi, 

this is not yet tested. Due to missing test-config in this bundle.
I am working on that in another [PR](https://github.com/metaclass-nl/filter-bundle/pull/4).

I added  "doctrine/orm" as dependency. But i am not sure about the minimum version.
Would be great if you can have a look at this PR.

Greetz