### PR TITLE
Fix when no where filter is used, don't apply 

### DIFF
--- a/src/Filter/FilterLogic.php
+++ b/src/Filter/FilterLogic.php
@@ -122,6 +122,11 @@ class FilterLogic extends AbstractContextAwareFilter
             $this->replaceInnerJoinsByLeftJoins($queryBuilder);
         }
 
+        // only add where if parts is filled.
+        if (count($logicExp->getParts()) === 0) {
+            return;
+        }
+        
         // if $existingWhere empty it does not matter how applied
         // if combinator == AND no problem
         // if  $filterWhere empty use andWhere


### PR DESCRIPTION
This fixes the default WHERE if empty. If i do not filter I got an Doctrine error, example:
`SELECT o, drivingRoutes_a1, openingHours_a2, openingHoursExceptions_a3 FROM App\\Entity\\Location o LEFT JOIN o.drivingRoutes drivingRoutes_a1 LEFT JOIN o.openingHours openingHours_a2 LEFT JOIN o.openingHoursExceptions openingHoursExceptions_a3 WHERE  ORDER BY o.id ASC`
As you can see the WHERE is empty.

Can you hotfix this? Dankjewel :)