### PR TITLE
Fix PHP8.4 deprecations

### DIFF
--- a/src/Filter/AddFakeLeftJoin.php
+++ b/src/Filter/AddFakeLeftJoin.php
@@ -34,7 +34,7 @@ class AddFakeLeftJoin implements FilterInterface
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        Operation $operation = null,
+        ?Operation $operation = null,
         array $context = []
     ): void {
        //  $queryBuilder->leftJoin(self::$FAKEJOIN, null);

--- a/src/Filter/DateFilter.php
+++ b/src/Filter/DateFilter.php
@@ -19,7 +19,7 @@ class DateFilter extends AbstractFilter implements DateFilterInterface
 
     private $inner;
 
-    public function __construct(ManagerRegistry $managerRegistry, LoggerInterface $logger = null, array $properties = null, NameConverterInterface $nameConverter = null)
+    public function __construct(ManagerRegistry $managerRegistry, ?LoggerInterface $logger = null, ?array $properties = null, ?NameConverterInterface $nameConverter = null)
     {
         parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
         $this->inner = new ApipDateFilter($managerRegistry, $logger, $properties, $nameConverter);
@@ -36,7 +36,7 @@ class DateFilter extends AbstractFilter implements DateFilterInterface
     /**
      * {@inheritdoc}
      */
-    protected function filterProperty(string $property, $values, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, Operation $operation = null, array $context = []): void
+    protected function filterProperty(string $property, $values, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
         // Expect $values to be an array having the period as keys and the date value as values
         if (!\is_array($values)) {

--- a/src/Filter/FilterLogic.php
+++ b/src/Filter/FilterLogic.php
@@ -60,7 +60,7 @@ class FilterLogic implements FilterInterface
      * {@inheritdoc}
      * @throws \LogicException if assumption proves wrong
      */
-    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, Operation $operation = null, array $context = []): void
+    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
         if (!isset($context['filters']) || !\is_array($context['filters'])) {
             throw new \InvalidArgumentException('::apply without $context[filters] not supported');
@@ -101,7 +101,7 @@ class FilterLogic implements FilterInterface
     /**
      * @throws \LogicException if assumption proves wrong
      */
-    protected function doGenerate($queryBuilder, $queryNameGenerator, $resourceClass, Operation $operation = null, $context)
+    protected function doGenerate($queryBuilder, $queryNameGenerator, $resourceClass, ?Operation $operation = null, $context)
     {
         if (empty($context['filters'])) {
             return [];
@@ -172,7 +172,7 @@ class FilterLogic implements FilterInterface
     /**
      * @throws \LogicException if assumption proves wrong
      */
-    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, Operation $operation = null, $context=[])
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, $context=[])
     {
         $subcontext = $context; //copies
         $subcontext['filters'] = $value;
@@ -180,7 +180,7 @@ class FilterLogic implements FilterInterface
     }
 
     /** Calls ::apply on each filter in $filters */
-    private function applyFilters($queryBuilder, $queryNameGenerator, $resourceClass, Operation $operation = null, $context)
+    private function applyFilters($queryBuilder, $queryNameGenerator, $resourceClass, ?Operation $operation = null, $context)
     {
         foreach ($this->filters as $filter) {
             $filter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
@@ -229,7 +229,7 @@ class FilterLogic implements FilterInterface
      * @param Operation $operation
      * @return FilterInterface[] From resource except $this and OrderFilters
      */
-    protected function getFilters(Operation $operation = null)
+    protected function getFilters(?Operation $operation = null)
     {
         $resourceFilters = $operation ? $operation->getFilters() : [];
 

--- a/src/Filter/RemoveFakeLeftJoin.php
+++ b/src/Filter/RemoveFakeLeftJoin.php
@@ -28,7 +28,7 @@ class RemoveFakeLeftJoin implements FilterInterface
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        Operation $operation = null,
+        ?Operation $operation = null,
         array $context = []
     ): void {
        self::removeItFrom($queryBuilder);


### PR DESCRIPTION
Fix PHP8.4 deprecations:

example:
```
Deprecated: Metaclass\FilterBundle\Filter\FilterLogic::apply(): Implicitly marking parameter $operation as nullable is deprecated, the explicit nullable type must be used instead
```

Added ? to all nullable parameters.