### PR TITLE
Update import for Symfony Extension class

### DIFF
--- a/src/DependencyInjection/MetaclassFilterExtension.php
+++ b/src/DependencyInjection/MetaclassFilterExtension.php
@@ -4,7 +4,7 @@ namespace Metaclass\FilterBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**


### PR DESCRIPTION
Symfony\Component\HttpKernel\DependencyInjection\Extension is marked as @internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead